### PR TITLE
Added shutdown for engine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/examples/data

--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@ TODO List:
 * [x] Middleware
 * [x] Repeaters
 * [x] RPC (Request / Reply)
-* [x] Context passthrough (Send needs to be modified to pass them through)
+* [x] context.Context
 * [ ] Events
-* [ ] Observability
-  * [ ] Logging
-  * [ ] Metrics
-  * [ ] Tracing
+* [x] Observability - *can be supported through middleware*
+  * [x] Logging - *slog will be used internally to log things (global)*
+  * [ ] Metrics - *metrics can be hooked up, but need to hook up engine metrics / deadletter metrics*
+  * [x] Tracing - *tracing is supported via middleware*
 * [ ] Go Docs
 * [x] CI
 * [ ] Remote Actors - this is where this will heavily deviate

--- a/actor.go
+++ b/actor.go
@@ -17,6 +17,9 @@ type Middleware func(ReceiverFunc) ReceiverFunc
 type poisonPill struct {
 	wg *sync.WaitGroup
 }
+type shutdownWaiter struct {
+	wg *sync.WaitGroup
+}
 
 type Initialized struct{}
 type Started struct{}

--- a/actor_test.go
+++ b/actor_test.go
@@ -5,8 +5,8 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/matryer/is"
 	"github.com/renevo/actor"
-	"github.com/stretchr/testify/assert"
 )
 
 type TestReceiveFunc func(*testing.T, *actor.Context)
@@ -28,6 +28,8 @@ func (r *TestReceiver) Receive(ctx *actor.Context) {
 }
 
 func TestMiddleware(t *testing.T) {
+	is := is.New(t)
+
 	engine := actor.NewEngine()
 	callCount := 0
 
@@ -52,5 +54,5 @@ func TestMiddleware(t *testing.T) {
 	engine.Poison(pid, wg)
 	wg.Wait()
 
-	assert.Equal(t, callCount, 4, "middleware was not called correct amount of times")
+	is.Equal(callCount, 4) // middleware was not called correct amount of times
 }

--- a/context.go
+++ b/context.go
@@ -4,6 +4,7 @@ import "context"
 
 type Context struct {
 	pid           PID
+	target        PID
 	sender        PID
 	engine        *Engine
 	receiver      Receiver

--- a/examples/children/main.go
+++ b/examples/children/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"sync"
 	"time"
 
 	"github.com/renevo/actor"
@@ -66,7 +65,5 @@ func main() {
 	pid := e.Spawn(newFooReceiver(), "foo")
 	e.Send(context.Background(), pid, message{data: fmt.Sprintf("msg_%d", 1)})
 
-	wg := &sync.WaitGroup{}
-	e.Poison(pid, wg)
-	wg.Wait()
+	e.ShutdownAndWait()
 }

--- a/examples/deadletter/main.go
+++ b/examples/deadletter/main.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"context"
+
+	"github.com/renevo/actor"
+)
+
+func main() {
+	engine := actor.NewEngine()
+
+	// TODO: need to show how to capture the event, as well as explain this a bit better...
+	engine.Send(context.Background(), actor.NewPID(actor.LocalAddress, "actor", "missing"), "hello")
+
+	engine.ShutdownAndWait()
+}

--- a/examples/helloworld/main.go
+++ b/examples/helloworld/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"sync"
 
 	"github.com/renevo/actor"
 )
@@ -38,7 +37,5 @@ func main() {
 		engine.Send(context.Background(), pid, &message{data: "hello world!"})
 	}
 
-	wg := &sync.WaitGroup{}
-	engine.Poison(pid, wg)
-	wg.Wait()
+	engine.ShutdownAndWait()
 }

--- a/examples/middleware/hooks/main.go
+++ b/examples/middleware/hooks/main.go
@@ -3,8 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"sync"
-	"time"
 
 	"github.com/renevo/actor"
 )
@@ -53,11 +51,6 @@ func main() {
 	// Send a message to foo
 	e.Send(context.Background(), pid, "Hello sailor!")
 
-	// We sleep here so we are sure foo received our message
-	time.Sleep(time.Second)
-
-	// Create a waitgroup so we can wait until foo has been stopped gracefully
-	wg := &sync.WaitGroup{}
-	e.Poison(pid, wg)
-	wg.Wait()
+	// calling ShutdownAndWait will guarantee that all messages before this call are processed
+	e.ShutdownAndWait()
 }

--- a/examples/middleware/persistence/main.go
+++ b/examples/middleware/persistence/main.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"reflect"
+	"time"
+
+	"github.com/renevo/actor"
+)
+
+const (
+	dataDir = "./examples/data"
+)
+
+type PersistedActor struct {
+	LastTime time.Time
+}
+
+func (p *PersistedActor) Receive(ctx *actor.Context) {
+	switch msg := ctx.Message().(type) {
+	case actor.Started:
+		slog.Info("Startup", "last", p.LastTime)
+	case actor.Stopped:
+		slog.Info("Shutdown", "last", p.LastTime)
+	case time.Time:
+		p.LastTime = msg
+	}
+}
+
+func main() {
+	_ = os.MkdirAll(dataDir, os.ModePerm)
+
+	engine := actor.NewEngine()
+	persistenceMiddleware := actor.WithMiddleware(func(next actor.ReceiverFunc) actor.ReceiverFunc {
+		return func(ctx *actor.Context) {
+			switch ctx.Message().(type) {
+			case actor.Initialized:
+				// load on initialize
+				if err := unmarshalActor(ctx.PID(), ctx.Receiver()); err != nil {
+					slog.Error("Failed to load actor", "err", err)
+				}
+
+				next(ctx)
+			case actor.Started:
+				// no need to save here
+				next(ctx)
+
+			default:
+				next(ctx)
+
+				// save after processing any other message
+				if err := marshalActor(ctx.PID(), ctx.Receiver()); err != nil {
+					slog.Error("Failed to save actor", "err", err)
+					return
+				}
+				slog.Info("Saved State", "actor", ctx.PID(), "msg", reflect.TypeOf(ctx.Message()))
+			}
+		}
+	})
+	pid := engine.Spawn(&PersistedActor{}, "persisted", persistenceMiddleware)
+
+	engine.Send(context.Background(), pid, time.Now())
+
+	// shutdown
+	engine.ShutdownAndWait()
+}
+
+func marshalActor(pid actor.PID, v any) error {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return fmt.Errorf("unable to marshal actor: %w", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(dataDir, pid.ID+".json"), data, os.ModePerm); err != nil {
+		return fmt.Errorf("unable to write actor data: %w", err)
+	}
+	return nil
+}
+
+func unmarshalActor(pid actor.PID, v any) error {
+	data, err := os.ReadFile(filepath.Join(dataDir, pid.ID+".json"))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("unable to read actor data: %w", err)
+	}
+
+	if err := json.Unmarshal(data, v); err != nil {
+		return fmt.Errorf("unable to unmarshal actor: %w", err)
+	}
+
+	return nil
+}

--- a/examples/middleware/subcontext/main.go
+++ b/examples/middleware/subcontext/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"sync"
 
 	"github.com/renevo/actor"
 )
@@ -36,7 +35,5 @@ func main() {
 	// this will overwrite the engine option context, so it is a good idea to use the one that was created originally
 	engine.Send(ctx, pid, "hello")
 
-	wg := &sync.WaitGroup{}
-	engine.Poison(pid, wg)
-	wg.Wait()
+	engine.ShutdownAndWait()
 }

--- a/examples/restarts/main.go
+++ b/examples/restarts/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"sync"
 
 	"github.com/renevo/actor"
 )
@@ -36,7 +35,5 @@ func main() {
 	engine.Send(context.Background(), pid, &message{data: "failed"})
 	engine.Send(context.Background(), pid, &message{data: "hello world!"})
 
-	wg := &sync.WaitGroup{}
-	engine.Poison(pid, wg)
-	wg.Wait()
+	engine.ShutdownAndWait()
 }

--- a/go.mod
+++ b/go.mod
@@ -2,10 +2,4 @@ module github.com/renevo/actor
 
 go 1.21
 
-require github.com/stretchr/testify v1.8.4
-
-require (
-	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
-)
+require github.com/matryer/is v1.4.1

--- a/go.sum
+++ b/go.sum
@@ -1,10 +1,2 @@
-github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
-github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
-github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
-github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
-gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+github.com/matryer/is v1.4.1 h1:55ehd8zaGABKLXQUe2awZ99BD/PTc2ls+KV/dXphgEQ=
+github.com/matryer/is v1.4.1/go.mod h1:8I/i5uYgLzgsgEloJE1U6xx5HkBQpAZvepWuujKwMRU=

--- a/processor.go
+++ b/processor.go
@@ -50,9 +50,9 @@ func (p *processor) PID() PID {
 	return p.pid
 }
 
-func (p *processor) Send(ctx context.Context, _ PID, msg any, from PID) {
+func (p *processor) Send(ctx context.Context, to PID, msg any, from PID) {
 	envelope := p.pool.Get().(*Envelope)
-	envelope.To = p.pid
+	envelope.To = to
 	envelope.From = from
 	envelope.Message = msg
 	envelope.Context = ctx
@@ -88,6 +88,7 @@ func (p *processor) Process(env *Envelope) {
 
 	p.context.message = env.Message
 	p.context.sender = env.From
+	p.context.target = env.To
 	p.context.ctx = env.Context
 
 	// TODO: Check to see if context.Deadline and drop if Options say we should

--- a/processor_test.go
+++ b/processor_test.go
@@ -3,18 +3,20 @@ package actor_test
 import (
 	"testing"
 
+	"github.com/matryer/is"
 	"github.com/renevo/actor"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestPID(t *testing.T) {
+	is := is.New(t)
+
 	pid := actor.NewPID(actor.LocalAddress, "test", "tag1", "tag2")
-	assert.Equal(t, pid.String(), "local.test.tag1.tag2")
-	assert.Equal(t, pid.ID, "test.tag1.tag2")
-	assert.Equal(t, pid.Address, "local")
+	is.Equal(pid.String(), "local.test.tag1.tag2")
+	is.Equal(pid.ID, "test.tag1.tag2")
+	is.Equal(pid.Address, "local")
 
 	cpid := pid.Child("child")
-	assert.Equal(t, cpid.String(), "local.test.tag1.tag2.child")
-	assert.Equal(t, cpid.ID, "test.tag1.tag2.child")
-	assert.Equal(t, cpid.Address, "local")
+	is.Equal(cpid.String(), "local.test.tag1.tag2.child")
+	is.Equal(cpid.ID, "test.tag1.tag2.child")
+	is.Equal(cpid.Address, "local")
 }

--- a/registry.go
+++ b/registry.go
@@ -41,3 +41,14 @@ func (r *registry) remove(pid PID) {
 	defer r.mu.Unlock()
 	delete(r.lookup, pid.ID)
 }
+
+func (r *registry) copy() map[PID]Processor {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	c := make(map[PID]Processor, len(r.lookup))
+	for k, v := range r.lookup {
+		c[PID{Address: r.engine.pid.Address, ID: k}] = v
+	}
+
+	return c
+}


### PR DESCRIPTION
This will poison all the direct root actors, which triggers poisons of all there children, etc... allowing for the entire system to finish processing and exit

Reworked tests to a simpler test package.