### PR TITLE
Adding engine logger with options

### DIFF
--- a/context.go
+++ b/context.go
@@ -1,6 +1,9 @@
 package actor
 
-import "context"
+import (
+	"context"
+	"log/slog"
+)
 
 type Context struct {
 	pid           PID
@@ -12,6 +15,7 @@ type Context struct {
 	ctx           context.Context
 	parentContext *Context
 	children      *safemap[string, PID]
+	logger        *slog.Logger
 }
 
 func newContext(e *Engine, pid PID) *Context {
@@ -19,6 +23,7 @@ func newContext(e *Engine, pid PID) *Context {
 		engine:   e,
 		pid:      pid,
 		children: newMap[string, PID](),
+		logger:   e.options.Logger.With("actor", pid.String()),
 	}
 }
 
@@ -111,4 +116,8 @@ func (c *Context) Context() context.Context {
 func (c *Context) WithContext(ctx context.Context) *Context {
 	c.ctx = ctx
 	return c
+}
+
+func (c *Context) Log() *slog.Logger {
+	return c.logger
 }

--- a/engine.go
+++ b/engine.go
@@ -25,6 +25,8 @@ func NewEngine(defaultOpts ...Option) *Engine {
 		InboxSize:    defaultInboxSize,
 		MaxRestarts:  defaultMaxRestarts,
 		RestartDelay: defaultRestartDelay,
+		Context:      context.Background(),
+		Logger:       slog.Default(),
 	}
 	for _, opt := range defaultOpts {
 		opt(options)
@@ -59,7 +61,7 @@ func NewEngine(defaultOpts ...Option) *Engine {
 				msg.wg.Wait()
 			}
 		default:
-			slog.Warn("Deadletter", "to", ctx.target, "from", ctx.sender, "msg", reflect.TypeOf(ctx.Message()))
+			ctx.Log().Warn("Deadletter", "to", ctx.target, "from", ctx.sender, "type", reflect.TypeOf(ctx.Message()))
 			// TODO: publish deadletter to Events once we have them
 		}
 	}, "engine", WithTags("deadletter"), WithInboxSize(defaultInboxSize*4))

--- a/examples/helloworld/main.go
+++ b/examples/helloworld/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/renevo/actor"
 )
@@ -20,13 +19,13 @@ func newFoo() actor.Receiver {
 func (f *foo) Receive(ctx *actor.Context) {
 	switch msg := ctx.Message().(type) {
 	case actor.Initialized:
-		fmt.Println("foot has initialized")
+		ctx.Log().Info("foot has initialized")
 	case actor.Started:
-		fmt.Println("foo has started")
+		ctx.Log().Info("foo has started")
 	case *message:
-		fmt.Println("foo has received", msg.data)
+		ctx.Log().Info("foo has received", "data", msg.data)
 	case actor.Stopped:
-		fmt.Println("foo has stopped")
+		ctx.Log().Info("foo has stopped")
 	}
 }
 

--- a/examples/middleware/hooks/main.go
+++ b/examples/middleware/hooks/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/renevo/actor"
 )
@@ -20,10 +19,10 @@ func newFoo() actor.Receiver {
 	return &foo{}
 }
 
-func (f *foo) Receive(c *actor.Context) {}
-func (f *foo) OnInit(c *actor.Context)  { fmt.Println("foo initialized") }
-func (f *foo) OnStart(c *actor.Context) { fmt.Println("foo started") }
-func (f *foo) OnStop(c *actor.Context)  { fmt.Println("foo stopped") }
+func (f *foo) Receive(ctx *actor.Context) {}
+func (f *foo) OnInit(ctx *actor.Context)  { ctx.Log().Info("foo initialized") }
+func (f *foo) OnStart(ctx *actor.Context) { ctx.Log().Info("foo started") }
+func (f *foo) OnStop(ctx *actor.Context)  { ctx.Log().Info("foo stopped") }
 
 func WithHooks() func(actor.ReceiverFunc) actor.ReceiverFunc {
 	return func(next actor.ReceiverFunc) actor.ReceiverFunc {

--- a/examples/middleware/subcontext/main.go
+++ b/examples/middleware/subcontext/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"context"
-	"fmt"
+	"reflect"
 
 	"github.com/renevo/actor"
 )
@@ -21,8 +21,7 @@ func main() {
 		func(ctx *actor.Context) {
 			hasEngineKey := ctx.Context().Value(engineKey)
 			hasMiddlewareKey := ctx.Context().Value(middlewareKey)
-
-			fmt.Printf("Engine: %t; Middleware: %t; Type: %T;\n", hasEngineKey, hasMiddlewareKey, ctx.Message())
+			ctx.Log().Info("Message", "engine", hasEngineKey, "middleware", hasMiddlewareKey, "type", reflect.TypeOf(ctx.Message()))
 		},
 		"test",
 		actor.WithMiddleware(func(next actor.ReceiverFunc) actor.ReceiverFunc {

--- a/examples/request/main.go
+++ b/examples/request/main.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"fmt"
 	"log"
+	"log/slog"
 	"time"
 
 	"github.com/renevo/actor"
@@ -30,13 +30,13 @@ func (r *nameResponder) Receive(ctx *actor.Context) {
 }
 
 func main() {
-	e := actor.NewEngine()
-	pid := e.Spawn(newNameResponder(), "responder")
+	engine := actor.NewEngine()
+	pid := engine.Spawn(newNameResponder(), "responder")
 	// Request a name and block till we got a response or the request timed out.
-	res, err := e.Request(pid, &nameRequest{}, time.Millisecond)
+	res, err := engine.Request(pid, &nameRequest{}, time.Millisecond)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	fmt.Println(res)
+	slog.Info("Response", "data", res)
 }

--- a/examples/restarts/main.go
+++ b/examples/restarts/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"context"
-	"fmt"
+	"time"
 
 	"github.com/renevo/actor"
 )
@@ -20,17 +20,17 @@ func newFoo() actor.Receiver {
 func (f *foo) Receive(ctx *actor.Context) {
 	switch msg := ctx.Message().(type) {
 	case actor.Started:
-		fmt.Println("foo started")
+		ctx.Log().Info("foo started")
 	case *message:
 		if msg.data == "failed" {
 			panic("I failed processing this message")
 		}
-		fmt.Println("I restarted and processed the next one perfectly:", msg.data)
+		ctx.Log().Info("I restarted and processed the next one perfectly", "data", msg.data)
 	}
 }
 
 func main() {
-	engine := actor.NewEngine()
+	engine := actor.NewEngine(actor.WithRestartDelay(time.Second * 1))
 	pid := engine.Spawn(newFoo(), "foo", actor.WithMaxRestarts(3))
 	engine.Send(context.Background(), pid, &message{data: "failed"})
 	engine.Send(context.Background(), pid, &message{data: "hello world!"})

--- a/options.go
+++ b/options.go
@@ -2,6 +2,7 @@ package actor
 
 import (
 	"context"
+	"log/slog"
 	"time"
 )
 
@@ -18,23 +19,15 @@ type Options struct {
 	Name         string
 	Receiver     Receiver
 	InboxSize    int
-	MaxRestarts  int32
+	MaxRestarts  int
 	RestartDelay time.Duration
 	Middleware   []Middleware
 	Tags         []string
 	Context      context.Context
+	Logger       *slog.Logger
 }
 
 type Option func(*Options)
-
-func DefaultOptions(receiver Receiver) Options {
-	return Options{
-		Receiver:     receiver,
-		InboxSize:    defaultInboxSize,
-		MaxRestarts:  defaultMaxRestarts,
-		RestartDelay: defaultRestartDelay,
-	}
-}
 
 func copyOptions(source *Options, receiver Receiver) *Options {
 	return &Options{
@@ -43,6 +36,7 @@ func copyOptions(source *Options, receiver Receiver) *Options {
 		MaxRestarts:  source.MaxRestarts,
 		RestartDelay: source.RestartDelay,
 		Context:      source.Context,
+		Logger:       source.Logger,
 	}
 }
 
@@ -60,7 +54,7 @@ func WithInboxSize(size int) Option {
 
 func WithMaxRestarts(n int) Option {
 	return func(opts *Options) {
-		opts.MaxRestarts = int32(n)
+		opts.MaxRestarts = n
 	}
 }
 
@@ -78,6 +72,18 @@ func WithTags(tags ...string) Option {
 
 func WithContext(ctx context.Context) Option {
 	return func(opt *Options) {
+		if ctx == nil {
+			ctx = context.Background()
+		}
 		opt.Context = ctx
+	}
+}
+
+func WithLogger(logger *slog.Logger) Option {
+	return func(opt *Options) {
+		if logger == nil {
+			logger = slog.Default()
+		}
+		opt.Logger = logger
 	}
 }

--- a/registry.go
+++ b/registry.go
@@ -1,7 +1,6 @@
 package actor
 
 import (
-	"log/slog"
 	"reflect"
 	"sync"
 )
@@ -29,7 +28,7 @@ func (r *registry) add(proc Processor) {
 
 	id := proc.PID().ID
 	if existing, ok := r.lookup[id]; ok {
-		slog.Warn("Attempt to register duplicate process.", "pid", proc.PID(), "existing", reflect.TypeOf(existing), "conflict", reflect.TypeOf(proc))
+		r.engine.options.Logger.Warn("Attempt to register duplicate process.", "pid", proc.PID(), "existing", reflect.TypeOf(existing), "conflict", reflect.TypeOf(proc))
 		return
 	}
 

--- a/request.go
+++ b/request.go
@@ -2,7 +2,6 @@ package actor
 
 import (
 	"context"
-	"log/slog"
 	"math/rand"
 	"reflect"
 	"strconv"
@@ -74,7 +73,7 @@ func (c *Context) Request(to PID, msg any, timeout time.Duration) (any, error) {
 
 func (c *Context) Respond(msg any) {
 	if c.sender.IsZero() {
-		slog.Warn("Call to Respond with no sender in context.", "pid", c.pid, "msg", reflect.TypeOf(msg))
+		c.logger.Warn("Call to Respond with no sender in context.", "pid", c.pid, "msg", reflect.TypeOf(msg))
 		return
 	}
 


### PR DESCRIPTION
This allows setting the slog.Logger for the entire engine. Actors will automatically add the 'actor' data with there full pid.String()

Cleaned up a lot of tests for consistency in code, was mix of styles, which is gross, still need to go through a lot of the code for style cleanups and constencies

Found a bug in panics during processor.Start, will open an issue for it