### PR TITLE
Reworked the processor to not block on init/start

### DIFF
--- a/actor.go
+++ b/actor.go
@@ -17,10 +17,8 @@ type Middleware func(ReceiverFunc) ReceiverFunc
 type poisonPill struct {
 	wg *sync.WaitGroup
 }
-type shutdownWaiter struct {
-	wg *sync.WaitGroup
-}
 
+type initialize struct{}
 type Initialized struct{}
 type Started struct{}
 type Stopped struct{}

--- a/examples/children/main.go
+++ b/examples/children/main.go
@@ -3,11 +3,15 @@ package main
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"github.com/renevo/actor"
 )
 
-var restarts = 0
+var (
+	restarts = 0
+	wg       sync.WaitGroup
+)
 
 type barReceiver struct {
 	data string
@@ -21,6 +25,8 @@ func newBarReceiver(data string) actor.Receiver {
 
 func (r *barReceiver) Receive(ctx *actor.Context) {
 	switch msg := ctx.Message().(type) {
+	case actor.Initialized:
+		ctx.Log().Info("initialized")
 	case actor.Started:
 		ctx.Log().Info("started")
 		if restarts < 2 {
@@ -28,8 +34,11 @@ func (r *barReceiver) Receive(ctx *actor.Context) {
 			panic("I will need to restart")
 		}
 		ctx.Log().Warn("bar recovered and started with initial state", "data", r.data)
-	case message:
-		ctx.Log().Info(msg.data)
+		wg.Done()
+
+	case string:
+		r.data = msg
+		ctx.Log().Info("Message", "data", msg)
 	case actor.Stopped:
 		ctx.Log().Info("stopped")
 	}
@@ -49,15 +58,14 @@ func (r *fooReceiver) Receive(ctx *actor.Context) {
 		ctx.Log().Info("started")
 	case message:
 		if r.barPID.ID == "" {
-			// this is a fundamental flaw in the system
-			// if bar panics, it bubbles the panic up to this actor instead of the child
-			// this then also creates an entry in the registry that has a borked up processor, and we don't get the pid back here
-			// might need to make the inbox a pull rather than a push, and processor.Start kick off a go routine instead of the go routine being in the inbox
-			r.barPID = ctx.Spawn(newBarReceiver(msg.data), "bar", actor.WithTags(msg.data))
+			r.barPID = ctx.Spawn(newBarReceiver(msg.data), "bar")
 			ctx.Log().Info("received and starting bar", "bar", r.barPID)
 		}
+
+		ctx.Send(ctx.Context(), r.barPID, msg.data)
+
 	case actor.Stopped:
-		ctx.Log().Info("will stop")
+		ctx.Log().Info("stopped")
 	}
 }
 
@@ -66,11 +74,13 @@ type message struct {
 }
 
 func main() {
+	wg.Add(1)
 	e := actor.NewEngine()
 	pid := e.Spawn(newFooReceiver(), "foo")
 	e.Send(context.Background(), pid, message{data: fmt.Sprintf("msg_%d", 1)})
-	e.Send(context.Background(), pid, message{data: fmt.Sprintf("msg_%d", 1)})
-	e.Send(context.Background(), pid, message{data: fmt.Sprintf("msg_%d", 1)})
+	e.Send(context.Background(), pid, message{data: fmt.Sprintf("msg_%d", 2)})
+	e.Send(context.Background(), pid, message{data: fmt.Sprintf("msg_%d", 3)})
+	wg.Wait()
 
 	e.ShutdownAndWait()
 }

--- a/examples/restarts/main.go
+++ b/examples/restarts/main.go
@@ -33,6 +33,8 @@ func main() {
 	engine := actor.NewEngine(actor.WithRestartDelay(time.Second * 1))
 	pid := engine.Spawn(newFoo(), "foo", actor.WithMaxRestarts(3))
 	engine.Send(context.Background(), pid, &message{data: "failed"})
+	engine.Send(context.Background(), pid, &message{data: "failed"})
+	engine.Send(context.Background(), pid, &message{data: "failed"})
 	engine.Send(context.Background(), pid, &message{data: "hello world!"})
 
 	engine.ShutdownAndWait()

--- a/inbox.go
+++ b/inbox.go
@@ -49,6 +49,7 @@ func (in *Inbox) Deliver(env *Envelope) error {
 	select {
 	case <-in.closeCh:
 		return ErrInboxClosed
+
 	default:
 		in.box <- env
 	}


### PR DESCRIPTION
The initialize, start, stop are now based on a loose state machines of when to send them during message processing. This keeps the init/start/stop from going out of order, as well as blocking the spawn functions. Additionally this fixes an issue with a panic in start/init actually not being captured properly by the restart mechanisms when spawning a new proc. Closes #11 by no longer failing when calling Start on a process.